### PR TITLE
Ported template to SCSS

### DIFF
--- a/lib/json2fontcss.js
+++ b/lib/json2fontcss.js
@@ -22,6 +22,9 @@ addMustacheTemplate('stylus', stylusTmpl);
 var lessTmpl = fs.readFileSync(templateDir + 'less.mustache.less', 'utf8');
 addMustacheTemplate('less', lessTmpl);
 
+var scssTmpl = fs.readFileSync(templateDir + 'scss.mustache.scss', 'utf8');
+addMustacheTemplate('scss', scssTmpl);
+
 addTemplate('json', require('./templates/json'));
 
 /**

--- a/lib/templates/scss.mustache.scss
+++ b/lib/templates/scss.mustache.scss
@@ -1,0 +1,45 @@
+{{#chars}}
+${{name}}-font-family: {{{escapedFontFamily}}};
+${{name}}-value: "\{{{value}}}";
+${{name}}: {{{escapedFontFamily}}} "\{{{value}}}";
+{{/chars}}
+
+@mixin iconFontFamily($char) {
+  font-family: nth($char,1);
+}
+
+@mixin iconFont() {
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+}
+
+@mixin iconContent($char) {
+  content: nth($char,2);
+}
+
+@mixin icon($char) {
+  @include iconFontFamily($char)
+  @include iconFont()
+
+  &:before {
+    @include iconContent($char)
+  }
+}
+
+@font-face {
+  font-family: {{{escapedFontFamily}}};
+  {{#fonts.eot}}
+  src:url("{{{fonts.eot}}}");
+  {{/fonts.eot}}
+  src:{{#fonts.eot}}url("{{{fonts.eot}}}?#iefix") format("embedded-opentype"),
+    {{/fonts.eot}}{{#fonts.woff}}url("{{{fonts.woff}}}") format("woff"),
+    {{/fonts.woff}}{{#fonts.ttf}}url("{{{fonts.ttf}}}") format("truetype"),
+    {{/fonts.ttf}}{{#fonts.svg}}url("{{{fonts.svg}}}#icomoon") format("svg"){{/fonts.svg}};
+  font-weight: normal;
+  font-style: normal;
+}

--- a/test/expected_files/scss.scss
+++ b/test/expected_files/scss.scss
@@ -1,49 +1,47 @@
-  $sprite1-x: 0px;
-  $sprite1-y: 0px;
-  $sprite1-offset-x: 0px;
-  $sprite1-offset-y: 0px;
-  $sprite1-width: 10px;
-  $sprite1-height: 20px;
-  $sprite1-image: 'nested/dir/spritesheet.png';
-  $sprite1: 0px 0px 0px 0px 10px 20px 'nested/dir/spritesheet.png';
-  $sprite2-x: 10px;
-  $sprite2-y: 20px;
-  $sprite2-offset-x: -10px;
-  $sprite2-offset-y: -20px;
-  $sprite2-width: 20px;
-  $sprite2-height: 30px;
-  $sprite2-image: 'nested/dir/spritesheet.png';
-  $sprite2: 10px 20px -10px -20px 20px 30px 'nested/dir/spritesheet.png';
-  $sprite3-x: 30px;
-  $sprite3-y: 50px;
-  $sprite3-offset-x: -30px;
-  $sprite3-offset-y: -50px;
-  $sprite3-width: 50px;
-  $sprite3-height: 50px;
-  $sprite3-image: 'nested/dir/spritesheet.png';
-  $sprite3: 30px 50px -30px -50px 50px 50px 'nested/dir/spritesheet.png';
+$icon1-font-family: "my-icon-set";
+$icon1-value: "\e0000";
+$icon1: "my-icon-set" "\e0000";
+$icon2-font-family: "my-icon-set";
+$icon2-value: "\e0001";
+$icon2: "my-icon-set" "\e0001";
+$icon3-font-family: "my-icon-set";
+$icon3-value: "\e0002";
+$icon3: "my-icon-set" "\e0002";
 
-  @mixin sprite-width($sprite) {
-    width: nth($sprite, 5);
-  }
+@mixin iconFontFamily($char) {
+  font-family: nth($char,1);
+}
 
-  @mixin sprite-height($sprite) {
-    height: nth($sprite, 6);
-  }
+@mixin iconFont() {
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+}
 
-  @mixin sprite-position($sprite) {
-    $sprite-offset-x: nth($sprite, 3);
-    $sprite-offset-y: nth($sprite, 4);
-    background-position: $sprite-offset-x  $sprite-offset-y;
-  }
+@mixin iconContent($char) {
+  content: nth($char,2);
+}
 
-  @mixin sprite-image($sprite) {
-    background-image: url(nth($sprite, 7));
-  }
+@mixin icon($char) {
+  @include iconFontFamily($char)
+  @include iconFont()
 
-  @mixin sprite($sprite) {
-    @include sprite-image($sprite);
-    @include sprite-position($sprite);
-    @include sprite-width($sprite);
-    @include sprite-height($sprite);
+  &:before {
+    @include iconContent($char)
   }
+}
+
+@font-face {
+  font-family: "my-icon-set";
+  src:url("abc/123/font.eot");
+  src:url("abc/123/font.eot?#iefix") format("embedded-opentype"),
+    url("abc/123/font.woff") format("woff"),
+    url("abc/123/font.ttf") format("truetype"),
+    url("abc/123/font.svg#icomoon") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}

--- a/test/json2fontcss_content.js
+++ b/test/json2fontcss_content.js
@@ -121,7 +121,7 @@ module.exports = {
       // Callback
       done(err);
     });
-  // },
+  },
 
   // // SASS
   // 'processed into SASS': [function () {
@@ -153,35 +153,35 @@ module.exports = {
   //   });
   // },
 
-  // // SCSS
-  // 'processed into SCSS': [function () {
-  //   this.options = {'format': 'scss'};
-  //   this.filename = 'scss.scss';
-  // }, 'processed via json2fontcss'],
-  // 'is valid SCSS': function (done) {
-  //   // Add some SCSS to our result
-  //   var scssStr = this.result;
-  //   scssStr += '\n' + [
-  //     '.feature {',
-  //     '  height: $sprite1-height;',
-  //     '  @include sprite-width($sprite2);',
-  //     '  @include sprite-image($sprite3);',
-  //     '}',
-  //     '',
-  //     '.feature2 {',
-  //     '  @include sprite($sprite2);',
-  //     '}'
-  //   ].join('\n');
+  // SCSS
+  'processed into SCSS': [function () {
+    this.options = {'format': 'scss'};
+    this.filename = 'scss.scss';
+  }, 'processed via json2fontcss'],
+  'is valid SCSS': function (done) {
+    // Add some SCSS to our result
+    var scssStr = this.result;
+    scssStr += '\n' + [
+      '.feature {',
+      '  height: $sprite1-height;',
+      '  @include sprite-width($sprite2);',
+      '  @include sprite-image($sprite3);',
+      '}',
+      '',
+      '.feature2 {',
+      '  @include sprite($sprite2);',
+      '}'
+    ].join('\n');
 
-  //   // Render the SCSS, assert no errors, and valid CSS
-  //   var tmp = new Tempfile();
-  //   tmp.writeFileSync(scssStr);
-  //   exec('sass --scss ' + tmp.path, function (err, css, stderr) {
-  //     assert.strictEqual(stderr, '');
-  //     assert.strictEqual(err, null);
-  //     assert.notEqual(css, '');
-  //     // console.log('SCSS', css);
-  //     done(err);
-  //   });
+    // Render the SCSS, assert no errors, and valid CSS
+    var tmp = new Tempfile();
+    tmp.writeFileSync(scssStr);
+    exec('sass --scss ' + tmp.path, function (err, css, stderr) {
+      assert.strictEqual(stderr, '');
+      assert.strictEqual(err, null);
+      assert.notEqual(css, '');
+      // console.log('SCSS', css);
+      done(err);
+    });
   }
 };


### PR DESCRIPTION
Great work with all of this. I am using grunt, font-smith and this to generate icons as soon as I drop an svg into a folder. I need this template so I can use the project in a team environment and it is included when dependencies are pulled from npm.

With this implementation, I tried to do an exact replica of your current templates.

If you are interested, I did a slightly different version in my local copy which I think is a little more flexible:
https://gist.github.com/lukebrooker/6694910

Not sure if it is possible with LESS though.
